### PR TITLE
Add support for koa with no orator dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SessionManager.connectRoutes(pFable.webServer);
 
 ## OratorSessionKoa
 
-For use with Koa, without opting into the entire Fable ecosystem, `OratorSessionKoa` takes a lighter approach. Calling `.middleware()` returns an array of middleware fuctions for use with a koa server.
+For use with Koa, without opting into the entire Fable ecosystem, `OratorSessionKoa` takes a lighter approach. `.middleware` is a middleware fuction for use with a koa server.
 
 Usage:
 
@@ -39,7 +39,7 @@ import { OratorSessionKoa } from 'orator-session'
 const app = new Koa(...)
 
 const sessionManager = new OratorSessionKoa(config, log, uuid)
-app.use(sessionManager.middleware())
+app.use(sessionManager.middleware)
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
 # Orator
 
-Orator-Session, meant to provide session and user auth for Orator web server (Orator 4.x and later). Requires Fable 3.x or later.
+Orator-Session, meant to provide session and user auth compatible with Orator web servers (Orator 4.x and later). It exposes two modules.
 
-## Dependencies
+## OratorSessionFable
 
-For now, this package depends on the web server instance having a registered query string parser, which is not included by default.
+For use with Fable / Restify, `OratorSessionFable` assumes the existence of both a query string parser (provided by Fable) and a cookie parser (the responsibility of the caller).
 
+Requires Fable 3.x or later.
+
+Calling `connectRoutes(webServer)` applies middleware to the server and registers several routes for managing sessions.
+
+Usage:
+
+```
+const pFable = (...create Fable instance...);
+
+const CookieParser = require('restify-cookies').parse;
+pFable.webServer.use(CookieParser);
+
+const OratorSessionFable = require('orator-session').OratorSessionFable;
+const SessionManager = new OratorSessionFable(pFable);
+SessionManager.connectRoutes(pFable.webServer);
+```
+
+## OratorSessionKoa
+
+For use with Koa, without opting into the entire Fable ecosystem, `OratorSessionKoa` takes a lighter approach. Calling `.middleware()` returns an array of middleware fuctions for use with a koa server.
+
+Usage:
+
+```
+import uuid from 'uuid'
+import config from 'config'
+import log from './log.js'
+
+import { OratorSessionKoa } from 'orator-session'
+
+const app = new Koa(...)
+
+const sessionManager = new OratorSessionKoa(config, log, uuid)
+app.use(sessionManager.middleware())
+```
+
+## Testing
+
+The automated tests assume that memcached is running on `localhost:11211`. Be sure to start it if you expect them to pass.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chai": "4.3.7",
     "codeclimate-test-reporter": "0.0.4",
     "fable": "^3.0.74",
+    "koa": "^2.14.2",
     "mocha": "10.2.0",
     "nyc": "^15.1.0",
     "orator": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@paviasystems/orator-session",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Session state and authentication manager for Orator Restful web API server.",
-  "main": "source/Orator-Session.js",
+  "main": "source/index.js",
   "scripts": {
     "coverage": "nyc npm run test --reporter=lcov",
-    "test": "mocha -u tdd -R spec",
+    "test": "mocha -u tdd -R spec -b",
     "tests": "mocha -u tdd -R spec -g"
   },
   "repository": {
@@ -31,11 +31,13 @@
     "nyc": "^15.1.0",
     "orator": "^4.0.1",
     "orator-serviceserver-restify": "^2.0.1",
+    "restify-cookies": "^0.2.6",
     "sinon": "^15.2.0",
     "supertest": "6.3.3"
   },
   "dependencies": {
     "memcached": "^2.2.2",
-    "restify-cookies": "^0.2.6"
+    "moment": "^2.29.4",
+    "uuid": "^9.0.1"
   }
 }

--- a/source/Orator-Session-Fable.js
+++ b/source/Orator-Session-Fable.js
@@ -1,0 +1,83 @@
+/**
+* Generalized session state and auth manager for Orator/restify
+*
+* @class OratorSession
+* @constructor
+*/
+
+const OratorSession = require('./Orator-Session.js');
+
+class OratorSessionFable extends OratorSession
+{
+	constructor(pFable)
+	{
+		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
+		{
+			throw new Error(`Invalid fable instance passed to OratorSession constructor. (${typeof(pFable)})`);
+		}
+
+		super(pFable.fable?.settings || pFable.settings || {}, pFable.log);
+
+		this._Fable = pFable;
+	}
+
+	/**
+	* Wire up middleware and routes for the OratorSession
+	*
+	* @method connectRoutes
+	* @param {Object} pRestServer The Restify server object to add routes to
+	*/
+	connectRoutes(pRestServer)
+	{
+		const restifyCall = (functionName) => (request, response, next) =>
+		{
+			request.response = response;
+			this[functionName](request, next);
+		}
+
+		// This means the getSession is called on every request
+		pRestServer.use(restifyCall('getSession'));
+
+		// This checks for a temp session token on every request
+		pRestServer.use(restifyCall('getTempSession'));
+
+		// This logs each request after the session is set
+		pRestServer.use(restifyCall('logSession'));
+
+		// Deauthenticate
+		pRestServer.get('/1.0/Deauthenticate', restifyCall('deAuthenticateUser'));
+
+		pRestServer.get('/1.0/CheckSession', restifyCall('checkSession'));
+
+		//checkout a temp token which allows 3rd party connection to use this session
+		pRestServer.get('/1.0/CheckoutSessionToken', restifyCall('getSessionToken'));
+
+		//We could add routes here to support different auth-types
+		// depending on configuration (WWW-Auth for example)
+
+		//In case of an Orator proxy, these endpoints need to be omitted
+		if (typeof(this._Fable.omitProxyRoute) == 'function')
+		{
+			this._Fable.omitProxyRoute('1.0/Deauthenticate');
+			this._Fable.omitProxyRoute('1.0/CheckSession');
+			this._Fable.omitProxyRoute('1.0/CheckoutSessionToken');
+		}
+	}
+
+	getRemoteAddress(pRequest)
+	{
+		return pRequest.connection.remoteAddress;
+	}
+
+	getCookie(pRequest, name)
+	{
+		return pRequest.cookies[name];
+	}
+
+	setCookie(pRequest, ...args)
+	{
+		pRequest.response.setCookie(...args);
+	}
+}
+
+module.exports = OratorSessionFable;

--- a/source/Orator-Session-Koa.js
+++ b/source/Orator-Session-Koa.js
@@ -12,21 +12,22 @@ class OratorSessionKoa extends OratorSession
 	constructor(settings, log)
 	{
 		super(settings, log);
-	}
 
-	/**
-	* Return array of koa middleware for OratorSession
-	*
-	* @method middleware
-	*/
-	middleware()
-	{
-		return [getSession, getTempSession, logSession]
+		this.middleware = (ctx, next) =>
+		{
+			this.getSession(ctx, () =>
+			{
+				this.getTempSession(ctx, () =>
+				{
+					this.logSession(ctx, next)
+				})
+			})
+		};
 	}
 
 	getRemoteAddress(ctx)
 	{
-		return ctx.response.connection.remoteAddress;
+		return ctx.res.connection.remoteAddress;
 	}
 
 	getCookie(ctx, name)

--- a/source/Orator-Session-Koa.js
+++ b/source/Orator-Session-Koa.js
@@ -1,0 +1,43 @@
+/**
+* Generalized session state and auth manager for Orator/restify
+*
+* @class OratorSession
+* @constructor
+*/
+
+const OratorSession = require('./Orator-Session.js');
+
+class OratorSessionKoa extends OratorSession
+{
+	constructor(settings, log)
+	{
+		super(settings, log);
+	}
+
+	/**
+	* Return array of koa middleware for OratorSession
+	*
+	* @method middleware
+	*/
+	middleware()
+	{
+		return [getSession, getTempSession, logSession]
+	}
+
+	getRemoteAddress(ctx)
+	{
+		return ctx.response.connection.remoteAddress;
+	}
+
+	getCookie(ctx, name)
+	{
+		return ctx.cookies.get(name);
+	}
+
+	setCookie(ctx, ...args)
+	{
+		ctx.cookies.set(...args)
+	}
+}
+
+module.exports = OratorSessionKoa;

--- a/source/Orator-Session.js
+++ b/source/Orator-Session.js
@@ -5,22 +5,16 @@
 * @constructor
 */
 
-const libCookieParser = require('restify-cookies');
 const libAsync = require('async');
 const libMoment = require('moment');
+const libUUID = require('uuid');
 
 class OratorSession
 {
-	constructor(pFable)
+	constructor(settings, log)
 	{
-		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
-		{
-			throw new Error(`Invalid fable instance passed to OratorSession constructor. (${typeof(pFable)})`);
-		}
-
-		this._Fable = pFable.fable; // parameter may not be a fable object, but "has" fable anyway
-		this._Settings = this._Fable.settings || { };
-		this._Log = this._Fable.log;
+		this._Settings = settings;
+		this._Log = log;
 
 		// Default settings value for session cookie name
 		if (!this._Settings.SessionCookieName)
@@ -38,44 +32,8 @@ class OratorSession
 			this._Settings.SessionStrategy = 'Memcached';
 		}
 
-		this._SessionStore = new (require(__dirname + '/strategies/' + this._Settings.SessionStrategy))(this._Fable);
+		this._SessionStore = new (require(__dirname + '/strategies/' + settings.SessionStrategy))(settings, log);
 		this._PassthroughURLs = new Set(['/ping.html', '/version']);
-	}
-
-	/**
-	* Wire up routes for the OratorSession
-	*
-	* @method connectRoutes
-	* @param {Object} pRestServer The Restify server object to add routes to
-	*/
-	connectRoutes(pRestServer)
-	{
-		pRestServer.use(libCookieParser.parse);
-		// This means the getSession is called on every request
-		pRestServer.use(this.getSession.bind(this));
-		// This checks for a temp session token on every request
-		pRestServer.use(this.getTempSession.bind(this)); //import session when ?SessionToken=temp_token_id
-		// This logs each request after the session is set
-		pRestServer.use(this.logSession.bind(this));
-
-		// Deauthenticate
-		pRestServer.get('/1.0/Deauthenticate', this.deAuthenticateUser.bind(this));
-
-		pRestServer.get('/1.0/CheckSession', this.checkSession.bind(this));
-
-		//checkout a temp token which allows 3rd party connection to use this session
-		pRestServer.get('/1.0/CheckoutSessionToken', this.getSessionToken.bind(this));
-
-		//We could add routes here to support different auth-types
-		// depending on configuration (WWW-Auth for example)
-
-		//In case of an Orator proxy, these endpoints need to be omitted
-		if (typeof(this._Fable.omitProxyRoute) == 'function')
-		{
-			this._Fable.omitProxyRoute('1.0/Deauthenticate');
-			this._Fable.omitProxyRoute('1.0/CheckSession');
-			this._Fable.omitProxyRoute('1.0/CheckoutSessionToken');
-		}
 	}
 
 	/**
@@ -93,7 +51,7 @@ class OratorSession
 		}
 		else
 		{
-			tmpSessionID = pRequest.cookies[this._Settings.SessionCookieName];
+			tmpSessionID = this.getCookie(pRequest, this._Settings.SessionCookieName);
 		}
 
 		if (!tmpSessionID)
@@ -113,7 +71,7 @@ class OratorSession
 	 *
 	 * @method getSession
 	 */
-	getSession(pRequest, pResponse, fNext)
+	getSession(pRequest, fNext)
 	{
 		if (this._PassthroughURLs.has(pRequest.url))
 		{
@@ -122,20 +80,19 @@ class OratorSession
 
 		if (!this.getSessionID(pRequest))
 		{
-			return this.createSession(pRequest, pResponse, fNext);
+			return this.createSession(pRequest, fNext);
 		}
-		//this._Log.trace('Cookie reports session '+this.getSessionID(pRequest));
 		this._SessionStore.get(this.getSessionID(pRequest), (pError, pData) =>
 		{
 			if (pError)
 			{
 				this._Log.trace('Session ID not found but cookie exists, creating a new session' + pError, { SessionID: this.getSessionID(pRequest) });
-				return this.createSession(pRequest, pResponse, fNext);
+				return this.createSession(pRequest, fNext);
 			}
 
 			if (!pData)
 			{
-				return this.createSession(pRequest, pResponse, fNext);
+				return this.createSession(pRequest, fNext);
 			}
 
 			//this._Log.trace('Restoring session', { SessionID: this.getSessionID(pRequest) });
@@ -156,7 +113,7 @@ class OratorSession
 	 * @method getTempSession
 	 * @params Querystring: ?SessionToken=temp_token_id
 	 */
-	getTempSession(pRequest, pResponse, fNext)
+	getTempSession(pRequest, fNext)
 	{
 		if (!pRequest.query.SessionToken)
 		{
@@ -216,24 +173,24 @@ class OratorSession
 	/**
 	* Get the currently logged in user
 	*/
-	checkSession(pRequest, pResponse, fNext)
+	checkSession(pRequest, fNext)
 	{
 		const tmpNext = (typeof(fNext) === 'function') ? fNext : () => { };
 
 		if (!pRequest[this._Settings.SessionCookieName].LoggedIn)
 		{
-			pResponse.send({ IDUser: 0, UserID:0, LoggedIn: false });
+			pRequest.response.send({ IDUser: 0, UserID:0, LoggedIn: false });
 			return tmpNext();
 		}
 
 		const tmpIDUser = pRequest[this._Settings.SessionCookieName].UserID;
 		if (tmpIDUser < 1)
 		{
-			pResponse.send({ IDUser: 0, UserID:0, LoggedIn: false });
+			pRequest.response.send({ IDUser: 0, UserID:0, LoggedIn: false });
 			return tmpNext();
 		}
 
-		pResponse.send(pRequest[this._Settings.SessionCookieName]);
+		pRequest.response.send(pRequest[this._Settings.SessionCookieName]);
 		return tmpNext();
 	}
 
@@ -242,10 +199,10 @@ class OratorSession
 	 *
 	 * @method createSession
 	 */
-	 createSession(pRequest, pResponse, fNext)
+	 createSession(pRequest, fNext)
 	 {
 		// Create a new session UUID...
-		const tmpUUID = this._Fable.getUUID();
+		const tmpUUID = libUUID.v4();
 		let tmpSessionID = 'SES' + tmpUUID;
 		let tmpNewSessionData = this.formatEmptyUserPacket(tmpSessionID, tmpUUID);
 
@@ -267,6 +224,7 @@ class OratorSession
 
 		this._SessionStore.get(tmpSessionID, (pError, pData) =>
 		{
+			this._Log.info('got', { pError, pData });
 			if (pError || !pData)
 			{
 				//this._Log.trace('Error checking if session exists in memcache' + pError, { SessionID: tmpSessionID });
@@ -277,7 +235,7 @@ class OratorSession
 						this._Log.trace('Error setting session: ' + (pError || 'no data returned from session provider'), { SessionID: tmpSessionID });
 					}
 					pRequest[this._Settings.SessionCookieName] = tmpNewSessionData;
-					pResponse.setCookie(this._Settings.SessionCookieName, tmpNewSessionData.SessionID,
+					this.setCookie(pRequest, this._Settings.SessionCookieName, tmpNewSessionData.SessionID,
 					{
 						path: '/',
 						maxAge: this._Settings.SessionTimeout,
@@ -297,7 +255,7 @@ class OratorSession
 					this._Log.trace('Error replacing session: ' + pError, { SessionID: tmpSessionID });
 				}
 				pRequest[this._Settings.SessionCookieName] = tmpNewSessionData;
-				pResponse.setCookie(this._Settings.SessionCookieName, tmpNewSessionData.SessionID,
+				this.setCookie(pRequest, this._Settings.SessionCookieName, tmpNewSessionData.SessionID,
 				{
 					path: '/',
 					maxAge: this._Settings.SessionTimeout,
@@ -340,6 +298,7 @@ class OratorSession
 			{
 				if (pError)
 				{
+					this._Log.trace('foo', this._Settings)
 					this._Log.trace('Error setting session status: ' + pError,
 					{
 						SessionID: pRequest[this._Settings.SessionCookieName].SessionID,
@@ -357,7 +316,7 @@ class OratorSession
 	/**
 	 * Log session state on Request
 	 */
-	logSession(pRequest, pResponse, fNext)
+	logSession(pRequest, fNext)
 	{
 		if (this._PassthroughURLs.has(pRequest.url))
 		{
@@ -366,7 +325,7 @@ class OratorSession
 
 		this._Log.info('Request',
 		{
-			ClientIP: pRequest.connection.remoteAddress,
+			ClientIP: this.getRemoteAddress(pRequest),
 			RequestUUID: pRequest.RequestUUID,
 			RequestURL: pRequest.url,
 			SessionID: pRequest[this._Settings.SessionCookieName].SessionID,
@@ -403,7 +362,7 @@ class OratorSession
 	 */
 	authenticateUser(pRequest, fAuthenticator, fCallBack)
 	{
-		const remoteIP = pRequest.headers['x-forwarded-for'] || pRequest.connection.remoteAddress;
+		const remoteIP = pRequest.headers['x-forwarded-for'] || this.getRemoteAddress(pRequest);
 		this._Log.trace('A user is attempting to login: ' + pRequest.Credentials.username,
 		{
 			RemoteIP: remoteIP,
@@ -476,7 +435,7 @@ class OratorSession
 	 *
 	 * @method deAuthenticateUser
 	 */
-	deAuthenticateUser(pRequest, pResponse, fNext)
+	deAuthenticateUser(pRequest, fNext)
 	{
 		this._Log.info('Deauthentication success',
 		{
@@ -487,7 +446,7 @@ class OratorSession
 		});
 		const tmpUserPacket = this.formatEmptyUserPacket(pRequest[this._Settings.SessionCookieName].SessionID);
 		this.setSessionLoginStatus(pRequest, tmpUserPacket);
-		pResponse.send({ Success: true });
+		pRequest.response.send({ Success: true });
 	}
 
 	/**
@@ -495,18 +454,18 @@ class OratorSession
 	 *
 	 * @method getSessionToken
 	 */
-	getSessionToken(pRequest, pResponse, fCallback)
+	getSessionToken(pRequest, fCallback)
 	{
 		this.checkoutSessionToken(pRequest, (err, token) =>
 		{
 			if (err)
 			{
 				//FIXME: :(
-				pResponse.send({ Error: err });
+				pRequest.response.send({ Error: err });
 			}
 			else
 			{
-				pResponse.send({ Token: token });
+				pRequest.response.send({ Token: token });
 			}
 
 			return fCallback();
@@ -526,7 +485,7 @@ class OratorSession
 			return fCallback('User not logged in!');
 		}
 
-		const tmpUUID = 'TempSessionToken-' + this._Fable.getUUID();
+		const tmpUUID = 'TempSessionToken-' + libUUID.v4();
 
 		this._SessionStore.set(tmpUUID, tmpSession.SessionID, this._Settings.SessionTempTokenTimeout, (pError) =>
 		{

--- a/source/Orator-Session.js
+++ b/source/Orator-Session.js
@@ -224,7 +224,6 @@ class OratorSession
 
 		this._SessionStore.get(tmpSessionID, (pError, pData) =>
 		{
-			this._Log.info('got', { pError, pData });
 			if (pError || !pData)
 			{
 				//this._Log.trace('Error checking if session exists in memcache' + pError, { SessionID: tmpSessionID });

--- a/source/index.js
+++ b/source/index.js
@@ -1,0 +1,5 @@
+module.exports =
+{
+  OratorSessionFable: require('./Orator-Session-Fable.js'),
+  OratorSessionKoa: require('./Orator-Session-Koa'),
+};

--- a/source/strategies/InMemory.js
+++ b/source/strategies/InMemory.js
@@ -11,16 +11,10 @@ const PRUNE_OPS = 100; //Prune session map every X set operations
 
 class InMemoryStrategy
 {
-	constructor(pFable)
+	constructor(settings, log)
 	{
-		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
-		{
-			throw new Error(`Invalid fable instance passed to OratorSession constructor. (${typeof(pFable)})`);
-		}
-
-		this._Fable = pFable.fable; // parameter may not be a fable object, but "has" fable anyway
-		this._Settings = pFable.settings || { };
-		this._Log = pFable.log;
+		this._Settings = settings;
+		this._Log = log;
 
 		this._Log.trace('Session Strategy is InMemory');
 

--- a/source/strategies/Memcached.js
+++ b/source/strategies/Memcached.js
@@ -10,16 +10,10 @@ const libMemcached = require('memcached');
 
 class MemcachedStrategy
 {
-	constructor(pFable)
+	constructor(settings, log)
 	{
-		if ((typeof(pFable) !== 'object') || !('fable' in pFable))
-		{
-			throw new Error(`Invalid fable instance passed to OratorSession constructor. (${typeof(pFable)})`);
-		}
-
-		this._Fable = pFable.fable; // parameter may not be a fable object, but "has" fable anyway
-		this._Settings = this._Fable.settings || { };
-		this._Log = this._Fable.log;
+		this._Settings = settings;
+		this._Log = log;
 
 		this._Log.trace('Session Strategy is Memcached: ' + this._Settings.MemcachedURL);
 		this._Memcached = new libMemcached(this._Settings.MemcachedURL);

--- a/test/Orator_session_inmemory_tests.js
+++ b/test/Orator_session_inmemory_tests.js
@@ -14,7 +14,7 @@ const libSuperTest = require('supertest');
 
 const Fable = require('fable');
 
-const OratorSession = require('../source/Orator-Session');
+const OratorSessionFable = require('../source/index').OratorSessionFable;
 
 const _MockSettings = (
 {
@@ -70,7 +70,7 @@ async function newOrator(fable)
 
 suite
 (
-	'OratorSession',
+	'OratorSessionFable',
 	function()
 	{
 		let _Orator;
@@ -82,7 +82,7 @@ suite
 		(
 			function()
 			{
-				_OratorSession = new OratorSession(new Fable(_MockSettings));
+				_OratorSession = new OratorSessionFable(new Fable(_MockSettings));
 			}
 		);
 
@@ -119,6 +119,7 @@ suite
 					{
 						_Fable = new Fable(_MockSettings);
 						_Orator = await newOrator(_Fable);
+						_Orator.webServer.use(require('restify-cookies').parse);
 					}
 				);
 				test
@@ -128,7 +129,7 @@ suite
 					{
 						// given
 						const fable2x = require('fable').new({});
-						const oratorSession = new OratorSession(fable2x);
+						const oratorSession = new OratorSessionFable(fable2x);
 						const webServer =
 						{
 							get: (route, endpointHandlerMethod) => { },
@@ -147,7 +148,7 @@ suite
 
 						// then
 						Expect(webServer.get.callCount).to.equal(3);
-						Expect(webServer.use.callCount).to.equal(4);
+						Expect(webServer.use.callCount).to.equal(3);
 					}
 				);
 				test
@@ -155,7 +156,7 @@ suite
 					'Start Orator web Server',
 					function(fTestComplete)
 					{
-						_OratorSession = new OratorSession(_Orator);
+						_OratorSession = new OratorSessionFable(_Orator);
 						_OratorSession.connectRoutes(_Orator.webServer);
 
 						//setup a route to use for testing

--- a/test/Orator_session_koa_tests.js
+++ b/test/Orator_session_koa_tests.js
@@ -1,0 +1,132 @@
+/**
+* Unit tests for Session state on Orator Server
+*
+* @license     MIT
+*
+* @author      Jason Hillier <jason@paviasystems.com>
+*/
+
+const Chai = require('chai');
+const Expect = Chai.expect;
+const Assert = Chai.assert;
+const Sinon = require('sinon');
+const Koa = require('koa');
+const libSuperTest = require('supertest');
+
+const Fable = require('fable');
+
+const OratorSessionKoa = require('../source/index').OratorSessionKoa;
+
+const _MockSettings = (
+{
+	Product: 'MockOratorAlternate',
+	ProductVersion: '0.0.0',
+	APIServerPort: 8999,
+	SessionTimeout: 60,
+	SessionStrategy: 'InMemory',
+	DefaultUsername: 'user',
+	DefaultPassword: 'test',
+});
+
+function newAgent()
+{
+	return libSuperTest.agent(`http://localhost:${_MockSettings.APIServerPort}/`);
+}
+
+suite
+(
+	'OratorSessionKoa',
+	function()
+	{
+		let _OratorSession;
+		let _SessionID;
+		const _SharedAgent = newAgent();
+
+		setup
+		(
+			function()
+			{
+        const fable = new Fable(_MockSettings);
+				_OratorSession = new OratorSessionKoa(fable.settings, fable.log);
+			}
+		);
+
+		suite
+		(
+			'Object Sanity',
+			function()
+			{
+				test
+				(
+					'initialize should build a happy little object',
+					function()
+					{
+						Expect(_OratorSession)
+							.to.be.an('object', 'Orator-Session should initialize as an object directly from the require statement.');
+					}
+				);
+			}
+		);
+
+		suite
+		(
+			'InMemory Orator Session with Koa web Server',
+			function()
+			{
+				let _Fable;
+				let _Koa;
+				let _OratorSession;
+				let _Server;
+
+				test
+				(
+					'Initialize Server',
+					function(done)
+					{
+						_Fable = new Fable(_MockSettings);
+						_Koa = new Koa();
+						_OratorSession = new OratorSessionKoa(_Fable.settings, _Fable.log);
+						_Koa.use(_OratorSession.middleware)
+						_Koa.use((ctx, next) => {
+							if (_OratorSession.checkIfLoggedIn(ctx))
+								ctx.status = 200;
+							else
+								ctx.status = 401;
+							ctx.body = 'TEST';
+						})
+						_Server = _Koa.listen(_MockSettings.APIServerPort);
+						_Server.on('listening', done)
+					}
+				);
+				test
+				(
+					'Send test request to create session',
+					function(fDone)
+					{
+						_SharedAgent
+								.get('TEST')
+								.end(
+									function (pError, pResponse)
+									{
+										Expect(pError).to.not.exist;
+										Expect(pResponse.text)
+											.to.contain('TEST');
+										Expect(pResponse.statusCode)
+											.to.equal(401);
+										fDone();
+									}
+								);
+					}
+				);
+				test
+				(
+					'Shutdown koa',
+					function()
+					{
+						_Server.close();
+					}
+				);
+			}
+		);
+	}
+);

--- a/test/Orator_session_memcached_tests.js
+++ b/test/Orator_session_memcached_tests.js
@@ -13,7 +13,7 @@ const libSuperTest = require('supertest');
 
 const Fable = require('fable');
 
-const OratorSession = require('../source/Orator-Session');
+const OratorSessionFable = require('../source/index').OratorSessionFable;
 
 const _MockSettings = (
 {
@@ -70,19 +70,18 @@ async function newOrator(fable)
 
 suite
 (
-	'OratorSession',
+	'OratorSessionFable',
 	function()
 	{
 		let _Orator;
 		let _OratorSession;
 		const _SharedAgent = newAgent();
 
-
 		setup
 		(
 			function()
 			{
-				_OratorSession = new OratorSession(new Fable(_MockSettings));
+				_OratorSession = new OratorSessionFable(new Fable(_MockSettings));
 			}
 		);
 
@@ -119,6 +118,7 @@ suite
 					{
 						_Fable = new Fable(_MockSettings);
 						_Orator = await newOrator(_Fable);
+						_Orator.webServer.use(require('restify-cookies').parse);
 					}
 				);
 				test
@@ -126,7 +126,7 @@ suite
 					'Start Orator web Server',
 					function()
 					{
-						_OratorSession = new OratorSession(_Orator);
+						_OratorSession = new OratorSessionFable(_Orator);
 						_OratorSession.connectRoutes(_Orator.webServer);
 
 						//setup a route to use for testing


### PR DESCRIPTION
Services that use Koa can now rely on the same sessions library as those that use orator. This increases the available options without worrying about incompatibility.

This PR is a breaking change, thus the 3.0 label. See the updated README for details about the new usage. It's very similar - now you use `require('orator-session').OratorSessionFable`, and users must apply a cookie-parsing middleware on their own.

Removing the dependency on restify-cookies (by requiring users to apply it themselves) means that the dependency tree is extremely slim, which is ideal for a library that can now be used by two different webservers.